### PR TITLE
Se agrega la propiedad 'file' al schema de anotaciones. Y el procesamiento del mismo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+This is a fork of https://github.com/zircote/swagger-php
+
 # swagger-php
 
 [![Build Status](https://api.travis-ci.org/zircote/swagger-php.png?branch=master)](http://travis-ci.org/zircote/swagger-php) `master`

--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,15 @@
 {
-    "name": "zircote/swagger-php",
+    "name": "gointegro/swagger-php",
     "type": "library",
     "license": "Apache2",
     "bin": ["bin/swagger"],
     "description": "Swagger-PHP - Generate interactive documentation for your RESTful API using phpdoc annotations",
     "keywords": ["json", "rest", "api", "service discovery"],
-    "homepage": "https://github.com/zircote/swagger-php/",
+    "homepage": "https://github.com/gointegro/swagger-php/",
     "authors": [
         {
-            "name": "Robert Allen",
-            "email": "zircote@gmail.com",
-            "homepage": "http://www.zircote.com"
-        },
-        {
-            "name": "Bob Fanger",
-            "email": "bfanger@gmail.com",
-            "homepage": "http://bfanger.nl"
+            "name": "Mariano G. Egui",
+            "email": "egui.mariano@gmail.com"
         }
     ],
     "config": {

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -277,6 +277,18 @@ abstract class AbstractAnnotation implements JsonSerializable
             }
             $data->$property = $object;
         }
+        // $file
+        if (isset($data->file)) {
+            $file = __DIR__.'/../../../../../'.$data->file;
+            if(is_file($file)){
+                $_schema = json_decode(file_get_contents($file));
+                $schema = new stdClass();
+                $schema->properties = $_schema->properties;
+                $data = $schema;
+            }else{
+                Logger::notice("File not Found: ".$data->file);
+            }
+        }
         // $ref
         if (isset($data->ref)) {
             $dollarRef = '$ref';

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -175,6 +175,12 @@ class Schema extends AbstractAnnotation
     public $discriminator;
 
     /**
+     * Adds support for files.
+     * @var string
+     */
+    public $file;
+
+    /**
      * Relevant only for Schema "properties" definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but MUST NOT be sent as part of the request. Properties marked as readOnly being true SHOULD NOT be in the required list of the defined schema. Default value is false.
      * @var boolean
      */
@@ -252,6 +258,7 @@ class Schema extends AbstractAnnotation
         'maxLength' => 'integer',
         'minLength' => 'integer',
         'pattern' => 'string',
+        'file' => 'string',
         'maxItems' => 'integer',
         'minItems' => 'integer',
         'uniqueItems' => 'boolean',


### PR DESCRIPTION
Su funcionalidad es levantar el contenido del archivo e introducirlo en el json para que Swagger pueda interpretarlo
OJO! de momento fue adaptado para el json a parsear tenga la propiedad 'properties', que sera lo que se incluya.
